### PR TITLE
Remove static references to `MutationEvent` in `environment.js`

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -238,7 +238,7 @@ var postLoadEvent = function(fn, that) {
         newValue : "null",
         prevValue : "null",
         eventPhase : window.Event.AT_TARGET,
-        attrChange: MutationEvent.ADDITION,
+        attrChange: 2, // MutationEvent.ADDITION,
         target: document,
         relatedNode: document,
         srcElement: document };
@@ -252,7 +252,7 @@ var postDomEventListener = function(fn, that) {
         newValue : "null",
         prevValue : "null",
         eventPhase : window.Event.AT_TARGET,
-        attrChange: MutationEvent.ADDITION,
+        attrChange: 2, // MutationEvent.ADDITION,
         target: document,
         relatedNode: document,
         srcElement: document };


### PR DESCRIPTION
Makes progress towards issue #2011 (but does not resolve it)

Replaces `MutationEvent` constants with their literal values.

[Reference](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent/attrChange#value)
