### PR TITLE
fix: update fixCSP for deprecation of 'X-Content-Security-Policy'

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -5902,7 +5902,7 @@ var webRequest = {
                 wrap();
                 break;
             } else if (Config.values.webrequest_fixCSP &&
-                       (item.name == 'X-WebKit-CSP' || item.name == 'X-Content-Security-Policy')) {
+                       (item.name == 'X-WebKit-CSP' || item.name == 'X-Content-Security-Policy' || item.name == 'Content-Security-Policy')) {
 
                 var n = item.value.replace(/script-src /, 'script-src ' + 'chrome-extension://' + chrome.extension.id + '/ \'unsafe-inline\' \'unsafe-eval\' ')
                 if (D) console.log('csp: replace "' + item.value + '" with "' + n + '"');


### PR DESCRIPTION
Since the "X-Content-Security-Policy" is deprecated and nowdays it's "Content-Security-Policy", this fix will allow eslint inline configurations like ```/* eslint semi: ["error", "always"] */``` which may depends underlying unsafe-eval to work without the CSP error prompt.