### PR TITLE
fix: update Chrome Web Store URLs to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ http://tampermonkey.net/donate.html
 DOWNLOADS:
 
 Tampermonkey (stable): 
-   https://chrome.google.com/webstore/detail/dhdgffkkebhmkfjojejmpbldmpobfkfo
+   https://chromewebstore.google.com/detail/dhdgffkkebhmkfjojejmpbldmpobfkfo
 
 Tampermonkey (beta): developer version, might contain bugs!
-   https://chrome.google.com/webstore/detail/gcalenpjmijncebpfijmoaglllgpjagf
+   https://chromewebstore.google.com/detail/gcalenpjmijncebpfijmoaglllgpjagf
 
 Tampermonkey (Legacy - Manifest version 1): for browsers based on Chromimum 17.
    http://tampermonkey.net/crx/tm_legacy.crx


### PR DESCRIPTION
## Summary

Updated Chrome Web Store URLs from the old format `chrome.google.com/webstore` to the new format `chromewebstore.google.com`.

## Changes

- Updated 2 URLs in README.md

This ensures the extension links work with the new Chrome Web Store URL format.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
