### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ http://tampermonkey.net/donate.html
 DOWNLOADS:
 
 Tampermonkey (stable): 
-   https://chrome.google.com/webstore/detail/dhdgffkkebhmkfjojejmpbldmpobfkfo
+   https://chromewebstore.google.com/detail/dhdgffkkebhmkfjojejmpbldmpobfkfo
 
 Tampermonkey (beta): developer version, might contain bugs!
-   https://chrome.google.com/webstore/detail/gcalenpjmijncebpfijmoaglllgpjagf
+   https://chromewebstore.google.com/detail/gcalenpjmijncebpfijmoaglllgpjagf
 
 Tampermonkey (Legacy - Manifest version 1): for browsers based on Chromimum 17.
    http://tampermonkey.net/crx/tm_legacy.crx


### PR DESCRIPTION
## Summary
- Updated 2 Chrome Web Store URLs from `chrome.google.com/webstore/detail/` to `chromewebstore.google.com/detail/` in README.md
- Google migrated the Chrome Web Store to a new domain; the old URLs currently redirect but may stop working in the future

## Test plan
- [x] Verified all updated URLs resolve correctly
- [x] No functional changes, docs-only update